### PR TITLE
Support macOS 10.15, iOS 13, tvOS 13, and watchOS 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package:Package = .init(
     name: "swift-hash",
-    platforms: [.macOS("13.3"), .iOS("16.4"), .tvOS("16.4"), .watchOS("9.4")],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "Base16",                targets: ["Base16"]),
         .library(name: "Base64",                targets: ["Base64"]),

--- a/Sources/MD5/MD5.swift
+++ b/Sources/MD5/MD5.swift
@@ -100,6 +100,7 @@ extension MD5:LosslessStringConvertible
         }
     }
 }
+@available(macOS 13.3, iOS 16.4, macCatalyst 16.4, tvOS 16.4, visionOS 1, watchOS 9.4, *)
 extension MD5:ExpressibleByIntegerLiteral
 {
     @inlinable public

--- a/Sources/MD5Tests/Main.swift
+++ b/Sources/MD5Tests/Main.swift
@@ -7,6 +7,20 @@ enum Main:TestMain, TestBattery
     static
     func run(tests:TestGroup)
     {
+        guard #available(
+            macOS 13.3,
+            iOS 16.4,
+            macCatalyst 16.4,
+            tvOS 16.4,
+            visionOS 1.0,
+            watchOS 9.4,
+            *
+        )
+        else
+        {
+            fatalError("MD5Tests requires macOS 13.3+, iOS 16.4+, tvOS 16.4+, visionOS 1.0+, or watchOS 9.4+")
+        }
+
         if  let tests:TestGroup = tests / "Strings"
         {
             let string:String   =   "d41d8cd98f00b204e9800998ecf8427e"

--- a/Sources/SHA1/SHA1.swift
+++ b/Sources/SHA1/SHA1.swift
@@ -83,6 +83,7 @@ extension SHA1:LosslessStringConvertible
         }
     }
 }
+@available(macOS 13.3, iOS 16.4, macCatalyst 16.4, tvOS 16.4, visionOS 1, watchOS 9.4, *)
 extension SHA1:ExpressibleByIntegerLiteral
 {
     @inlinable public


### PR DESCRIPTION
I would like to use `swift-png` on macOS versions earlier than macOS 13.3, and afaict `swift-hash` is the only reason that `swift-png` requires macOS 13.3+. The changes to support macOS versions back to 10.15 were luckily pretty minimal. While I was at it I also added the corresponding iOS, tvOS, etc versions to my availability checks (but I haven't tested compilation on those platforms, only on macOS).

### Changes

- Added `@available` annotations to `ExpressibleByIntegerLiteral` implementations that rely on `StaticBigInt`
- Used `#available` to provide an alternative `CustomStringConvertible` implementation for `InlineBuffer` when `String.init(unsafeUninitializedCapacity:initializingUTF8With:)` isn't available
- Limited `MD5Tests` to macOS 13.3+ since those tests rely heavily on being able to express `MD5` using integer literals. This was achieved using a runtime check because I couldn't find a way to make it a compile-time check (there doesn't seem to be compile-time conditional that allows checking platform versions), but if you know a way I'd be happy to update my implementation.

The alternative implementation for `InlineBuffer.description` probably isn't as efficient as the post `macOS 11` implementation unless the compiler does something clever, but given that the older platforms weren't supported at all before I reckon this is an ok compromise (and swift-png doesn't rely on that part of the code 😅).

