### PR TITLE
Manually specialize parts of CRC32 implementation to speed them up debug mode

### DIFF
--- a/Sources/CRC/CRC32.swift
+++ b/Sources/CRC/CRC32.swift
@@ -40,6 +40,18 @@ struct CRC32:Hashable, Sendable
         return checksum
     }
 
+    /// Returns a new checksum by hashing the provided message into the current checksum.
+    ///
+    /// This manually specialized implementation is much faster in debug mode than the
+    /// generic implementation, but exactly the same in release mode.
+    @inlinable public
+    func updated(with message:borrowing [UInt8]) -> Self
+    {
+        var checksum:Self = self
+        checksum.update(with: message)
+        return checksum
+    }
+
     /// Updates the checksum by hashing the provided message into the existing checksum.
     @inlinable public mutating
     func update(with message:borrowing some Sequence<UInt8>)
@@ -47,8 +59,70 @@ struct CRC32:Hashable, Sendable
         self.checksum = ~message.reduce(~self.checksum)
         {
             (state:UInt32, byte:UInt8) in
-            Self.table[Int.init(UInt8.init(truncatingIfNeeded: state) ^ byte)] ^ state >> 8
+            let indexByte:UInt8 = UInt8.init(truncatingIfNeeded: state) ^ byte
+            let index:Int
+            #if DEBUG
+                // in debug mode these hacky integer conversions make this function
+                // around 35% faster
+                if MemoryLayout<Int>.stride == 8 {
+                    let tuple:(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) =
+                    (
+                        indexByte, 0, 0, 0, 0, 0, 0, 0
+                    )
+                    index = unsafeBitCast(tuple, to: Int.self)
+                } else {
+                    let tuple:(UInt8, UInt8, UInt8, UInt8) =
+                    (
+                        indexByte, 0, 0, 0
+                    )
+                    index = unsafeBitCast(tuple, to: Int.self)
+                }
+            #else
+                index = Int.init(indexByte)
+            #endif
+            return Self.table[index] ^ state >> 8
         }
+    }
+
+    /// Updates the checksum by hashing the provided message into the existing checksum.
+    ///
+    /// This manually specialized implementation is much faster in debug mode than the
+    /// generic implementation, but exactly the same in release mode.
+    @inlinable public mutating
+    func update(with message:borrowing [UInt8])
+    {
+        #if DEBUG
+            // in debug mode this manually specialized version of `reduce` is about 2.8x faster
+            self.checksum = ~self.checksum
+            var i:Int = 0
+            while i < message.count
+            {
+                let state:UInt32 = self.checksum
+                let byte:UInt8 = message[i]
+                let indexByte:UInt8 = UInt8.init(truncatingIfNeeded: state) ^ byte
+                let index:Int
+                // in debug mode these hacky integer conversions make this function
+                // around 35% faster
+                if MemoryLayout<Int>.stride == 8 {
+                    let tuple:(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) =
+                    (
+                        indexByte, 0, 0, 0, 0, 0, 0, 0
+                    )
+                    index = unsafeBitCast(tuple, to: Int.self)
+                } else {
+                    let tuple:(UInt8, UInt8, UInt8, UInt8) =
+                    (
+                        indexByte, 0, 0, 0
+                    )
+                    index = unsafeBitCast(tuple, to: Int.self)
+                }
+                self.checksum = Self.table[index] ^ state >> 8
+                i += 1
+            }
+            self.checksum = ~self.checksum
+        #else
+            self.update(with: message[...])
+        #endif
     }
 }
 extension CRC32:ExpressibleByIntegerLiteral


### PR DESCRIPTION
These changes are related to [my debug mode optimisation PR on for `swift-png`](https://github.com/tayloraswift/swift-png/pull/77) and have to be merged before that PR can be merged.

These optimisations corresponded to about a 20% improvement in debug mode PNG decoding at the time that I implemented them.

Please tag a new version (probably just a patch version?) once this is merged to that I can update my `swift-png` PR to point to it.